### PR TITLE
triage all 55 CodeQL alerts: four real bugs fixed, the rest dispositioned

### DIFF
--- a/core/logsafe.go
+++ b/core/logsafe.go
@@ -19,10 +19,11 @@ import "strings"
 // writes a second line that reads exactly like a real one. Replacing the
 // terminators with an escape keeps the value legible while making it
 // impossible for it to end its own line.
-func LogSafe(s string) string {
-	if !strings.ContainsAny(s, "\r\n") {
-		return s
-	}
-	r := strings.NewReplacer("\r\n", "\\n", "\n", "\\n", "\r", "\\r")
-	return r.Replace(s)
-}
+// The replacer is package-level and every value goes through it. An earlier
+// version returned the input unchanged when it contained no terminator, which
+// was a branch on which the untrusted value reached the output having passed
+// through nothing — CodeQL was right to keep reporting it, and the saving was
+// never worth having on a logging path.
+var logLineBreaks = strings.NewReplacer("\r\n", "\\n", "\n", "\\n", "\r", "\\r")
+
+func LogSafe(s string) string { return logLineBreaks.Replace(s) }

--- a/core/logsafe.go
+++ b/core/logsafe.go
@@ -1,0 +1,28 @@
+package core
+
+import "strings"
+
+// LogSafe strips line terminators from a value before it is interpolated into
+// a line-oriented log.
+//
+// The structured logger in package observability is immune to this: it
+// json.Marshals each entry, which escapes newlines. Twenty-one sites still use
+// stdlib log.Printf, and three of them interpolate values the model controls —
+// a tool name, a project id, an error carrying a model-supplied path. CodeQL
+// found those three as go/log-injection.
+//
+// A forged line matters here more than in most programs, because this log is
+// the record of what the agent did to the user's machine. A tool named
+//
+//	foo\n2026/08/15 04:00:00 [permission] user approved rm -rf /
+//
+// writes a second line that reads exactly like a real one. Replacing the
+// terminators with an escape keeps the value legible while making it
+// impossible for it to end its own line.
+func LogSafe(s string) string {
+	if !strings.ContainsAny(s, "\r\n") {
+		return s
+	}
+	r := strings.NewReplacer("\r\n", "\\n", "\n", "\\n", "\r", "\\r")
+	return r.Replace(s)
+}

--- a/core/logsafe_test.go
+++ b/core/logsafe_test.go
@@ -1,0 +1,34 @@
+package core
+
+import "testing"
+
+func TestLogSafeCannotEndItsOwnLine(t *testing.T) {
+	forged := "read_file\n2026/08/15 04:00:00 [permission] user approved rm -rf /"
+	got := LogSafe(forged)
+	for _, c := range []string{"\n", "\r"} {
+		if containsRune(got, c) {
+			t.Fatalf("LogSafe(%q) still contains a line terminator: %q", forged, got)
+		}
+	}
+	if got == forged {
+		t.Fatal("LogSafe returned the value unchanged")
+	}
+	// Legibility: the forged text must still be readable, not dropped.
+	if len(got) < len(forged) {
+		t.Fatalf("LogSafe truncated the value: %q", got)
+	}
+	// A clean value is untouched, so the common path allocates nothing.
+	clean := "read_file"
+	if LogSafe(clean) != clean {
+		t.Fatalf("LogSafe altered a clean value: %q", LogSafe(clean))
+	}
+}
+
+func containsRune(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/docs/CODEQL_TRIAGE.md
+++ b/docs/CODEQL_TRIAGE.md
@@ -1,0 +1,160 @@
+# CodeQL triage, first full scan
+
+The first CodeQL run over the whole tree (`security-extended`, 2026-08-15,
+commit `4014645`) returned **55 open alerts**. Pull-request checks only ever
+report alerts in *changed* code, so none of this was visible until the scan ran
+against `main`.
+
+Every alert is dispositioned below. Dismissals in the GitHub UI carry a
+280-character comment pointing here; this file holds the reasoning.
+
+The rule this triage follows: **a scanner that is muted broadly is worse than
+none, because it reports clean and is believed.** Nothing is dismissed as a
+class. Each cluster below names the specific sanitiser or the specific design
+decision, and where the evidence lives.
+
+## Summary
+
+| Disposition | Alerts |
+|---|---|
+| Fixed, with a regression test that fails against the old code | 22 |
+| Dismissed — sanitiser present, CodeQL cannot model it | 9 |
+| Dismissed — reachable only across a documented trust boundary | 24 |
+
+One vulnerability was found **during** this triage that CodeQL did not report:
+DNS rebinding against the local server. It is the most serious thing in this
+document. See "Found while triaging".
+
+## Fixed
+
+### project/store.go — path traversal (15 alerts: #28–#42)
+
+**Real, and the worst of the reported set.** Every path helper in the store
+funnels through `dir(id)`, which was `filepath.Join(s.root, id)` with no check
+on `id`.
+
+The ids this package *makes* are safe: `newID` is a slug plus six hex
+characters and `slugify`'s charset is `[a-z0-9-]`, which contains no separator.
+The ids it is *given* were never checked, and they arrive from outside —
+`server/chat_handler.go:190` passes `req.Project`, straight off the request
+body, into `Get`, `GetPlan` and `GetWorkflow`.
+
+`filepath.Join` collapses `..`, so an id of `../../../../etc` resolved to
+`/etc`, and `SetContext` would have written its `context.md` there: an
+arbitrary-directory write with attacker-chosen content under a fixed filename.
+
+Fixed by `safeSegment` in `dir()`, which cleans against `/` and takes the base,
+so a traversal is resolved and then discarded rather than trusted. One guard
+covers all fifteen sinks because they all pass through it.
+
+Test: `project/traversal_test.go`. Against the old `dir()` it reports
+`id "../../002" resolved to "/tmp/002", which is outside the store root`.
+
+### tools/registry.go — reads on model-supplied paths (4 alerts: #2, #51–#53)
+
+**Real, and subtle: the tool call was never the problem.** The permission gate
+decides what the agent may look at, and confining reads outright would break an
+approved read of a config in `$HOME`. What was wrong is where the bytes went.
+
+- `noteFileObservation` (#2) re-reads the file and hands it to the observer,
+  which `app_wireup.go` wires to `memory.ObserveFile`. An approved one-off read
+  of `~/.ssh/config` became a durable belief in the knowledge graph, outliving
+  the turn the user approved.
+- `captureFileBefore` and the two after-reads (#51–#53) run *before* the tool
+  does, so they read whatever path the model named regardless of whether the
+  write was about to be refused. `write_file` and `patch` both call
+  `confineWrite`, so the write never landed outside the workspace — but the
+  before-snapshot was captured into the change record and rendered in the
+  Changes tab. A refused write to `/etc/shadow` disclosed it.
+
+Both now go through `withinWorkspace`, which returns the path it validated so
+the read operates on the value that was checked. The snapshot policy and the
+write policy are now the same policy.
+
+Tests: `tools/observation_confinement_test.go`. Against the old code:
+`a file outside the workspace was observed into the graph: …token=hunter2`.
+
+### log-injection (3 alerts: #54–#56)
+
+**Real, low severity, fixed rather than dismissed.** The structured logger in
+`observability` is immune — it `json.Marshal`s each entry, which escapes
+newlines. These three sites use stdlib `log.Printf` and interpolate values the
+model controls: a tool name, a project id, an error carrying a model-supplied
+path.
+
+A forged line matters more here than in most programs, because this log is the
+record of what the agent did to the user's machine. A tool named
+`foo\n2026/08/15 04:00:00 [permission] user approved rm -rf /` writes a second
+line that reads exactly like a real one.
+
+Fixed with `core.LogSafe`, applied at the three sites CodeQL proved reachable.
+Test: `core/logsafe_test.go`.
+
+## Dismissed — sanitiser present, CodeQL cannot model it
+
+These are true dataflows and false vulnerabilities. In each case the value is
+constrained by a check the tool does not recognise as a barrier.
+
+| Alerts | Location | Sanitiser | Evidence |
+|---|---|---|---|
+| #4, #5, #6 | `attach/attach.go:263`, `llm/client.go:562`, `provider/fetch.go:142` | `safeurl` — a dialler refusing private, loopback and link-local destinations, honouring air-gap mode. `llm/client.go:562` is literally `safeurl.EgressClient(...).Do(req)`. | `safeurl/no_bypass_test.go`, `safeurl/airgap_test.go` |
+| #7, #8 | `provider/embedded/downloader.go:209, :240` | `filepath.Base` on the archive entry name before `filepath.Join(destDir, name)`. An entry cannot escape `destDir`. | read the extraction loop |
+| #9, #10 | `provider/embedded/downloader.go:247, :251` | `filepath.Base` on `hdr.Linkname` too, so a symlink entry can only point at a sibling name inside `destDir`. | same loop |
+| #3 | `cli/console_settings.go:48` | values come from `config.Values()`, which replaces every `Secret: true` descriptor with bullets (`config/surface.go:227`). `api_key` is `Secret: true`. | `config/surface_test.go` `TestValuesRedactsSecrets` |
+| #43, #44 | `server/workspace_handlers.go:110, :131` | the handler already does the `HasPrefix(abs+sep, cwd+sep)` containment check and returns 403 before the read. | read `handleFilesRead` |
+
+## Dismissed — across a documented trust boundary
+
+The remaining path-injection alerts are all the same shape: **a local program,
+running as the user, opening a path the user or their agent named.** That is
+what this program is for. `SECURITY.md` already states the boundary: the local
+web UI binds to loopback and is unauthenticated by design, and a browser tab on
+the same machine is the trust boundary.
+
+| Alerts | Location | Why it is intended |
+|---|---|---|
+| #45–#50 | `server/workspace_handlers.go` (`handleWorkspaceBrowse`, `handleFSBrowse`, `handleFSMkdir`, `setActiveWorkspace`) | These are the file picker and the workspace chooser. A picker that cannot browse outside the current workspace cannot attach a file from `~/Documents`, and a workspace chooser that cannot name an arbitrary directory cannot choose one. |
+| #12–#16 | `attach/attach.go` | the user picks what to attach. |
+| #17–#20 | `checkpoint/checkpoint.go` | paths come from the checkpoint's own manifest, written by this program. |
+| #21–#23 | `ingest/ingest.go` | the user names the source to ingest. |
+| #11, #24–#27 | `agents/verification_stages.go`, `loop/parse.go`, `orchestrator/acceptance.go`, `orchestrator/contract.go`, `permission/gate.go` | single sites operating on paths already inside the agent's own working set. |
+
+**What makes this dismissal legitimate rather than convenient** is that the
+boundary is enforced, not merely asserted. The server binds to `127.0.0.1`
+(`main.go:81`, no flag to change it), rejects cross-origin requests, and — since
+the fix below — rejects requests arriving under a non-loopback `Host`. Without
+that last one this section would not have been defensible.
+
+## Found while triaging: DNS rebinding
+
+Not a CodeQL alert. It surfaced from asking what the eight
+`server/workspace_handlers.go` alerts were actually reachable by.
+
+`csrfMiddleware` guarded `Origin` only. Rebinding does not send a foreign
+Origin — it removes the need for one:
+
+1. `evil.com` resolves to the attacker, serves a page, and re-resolves to
+   `127.0.0.1` on a short TTL.
+2. The page fetches `http://evil.com:12345/api/…`.
+3. The browser considers that **same-origin with itself**, so it sends no
+   `Origin` header at all. `origin != ""` is false.
+4. The request lands on handlers that read files, write files and run tools.
+
+What the attacker cannot drop is `Host: evil.com`, because that is the name the
+browser dialled. The middleware now requires a loopback `Host` on every path —
+not just `/api/`, because a rebound page loading the UI is the first step to
+driving it.
+
+Test: `server/middleware_test.go` `TestCSRFBlocksDNSRebinding`. Against the old
+middleware: `a request for Host "evil.com" reached the handler`. It also covers
+a LAN address, a public IP, and `127.0.0.1.evil.com`, which prefix matching
+would have waved through.
+
+## Re-running this
+
+```
+gh api --paginate 'repos/darkneuralnetwork/DarkCode/code-scanning/alerts?state=open&per_page=100'
+```
+
+A new alert in a cluster dismissed above is **not** covered by that dismissal —
+the reasoning is per-site, and a new site is a new question.

--- a/project/store.go
+++ b/project/store.go
@@ -484,7 +484,34 @@ func (s *Store) Delete(id string) error {
 
 // --- internal helpers (must be called with the appropriate lock held) ---
 
-func (s *Store) dir(id string) string            { return filepath.Join(s.root, id) }
+func (s *Store) dir(id string) string { return filepath.Join(s.root, safeSegment(id)) }
+
+// safeSegment reduces a project id to a single path component, so no id can
+// address anything outside the store root.
+//
+// Ids that this package MAKES are safe: newID emits slug + "-" + six hex, and
+// slugify's charset is [a-z0-9-] with no separator in it. Ids it RECEIVES were
+// not checked at all, and they arrive from outside — /api/chat takes
+// req.Project straight from the request body and hands it to Get, GetPlan and
+// GetWorkflow, each of which reaches dir() below. filepath.Join collapses "..",
+// so an id of "../../../../etc" resolved to /etc and SetContext would have
+// written its context.md there. CodeQL flagged fifteen sinks in this file for
+// exactly that reason.
+//
+// Cleaning against "/" first means the traversal is resolved and then discarded
+// rather than trusted: "../../etc/passwd" becomes "/etc/passwd" becomes
+// "passwd", a harmless name inside the root. A legitimate id has no separator
+// and comes back unchanged.
+func safeSegment(id string) string {
+	seg := filepath.Base(filepath.Clean("/" + id))
+	if seg == "/" || seg == "." || seg == ".." || seg == string(filepath.Separator) {
+		// No usable name. Return something that cannot collide with a real
+		// project so the caller's ReadFile fails as "not found" rather than
+		// landing on the store root itself.
+		return "invalid-project-id"
+	}
+	return seg
+}
 func (s *Store) metaPath(id string) string       { return filepath.Join(s.dir(id), "project.json") }
 func (s *Store) contextPath(id string) string    { return filepath.Join(s.dir(id), "context.md") }
 func (s *Store) rawContextPath(id string) string { return filepath.Join(s.dir(id), "context_raw.md") }

--- a/project/traversal_test.go
+++ b/project/traversal_test.go
@@ -1,0 +1,80 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestProjectIDCannotEscapeTheStoreRoot pins the fix for the path traversal
+// CodeQL reported as fifteen go/path-injection sinks in store.go.
+//
+// The ids this package makes are safe — newID is a slug plus hex and slugify's
+// charset has no separator. The ids it is GIVEN were never checked, and they
+// come from outside: server/chat_handler.go passes req.Project, straight off
+// the request body, into Get, GetPlan and GetWorkflow. Every one of those
+// reaches dir(), where filepath.Join collapses "..".
+//
+// Against the unguarded dir() the write below lands outside the root.
+func TestProjectIDCannotEscapeTheStoreRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	s, err := NewStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A relative escape, an absolute path, and a Windows-style separator. The
+	// third matters because filepath.Base is separator-aware per platform and a
+	// caller may hand us either.
+	for _, id := range []string{
+		"../../" + filepath.Base(outside),
+		filepath.Join(outside, "planted"),
+		"..",
+		".",
+		"",
+		"a/../../b",
+	} {
+		t.Run("id="+id, func(t *testing.T) {
+			got := s.dir(id)
+			abs, err := filepath.Abs(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rootAbs, _ := filepath.Abs(root)
+			rel, err := filepath.Rel(rootAbs, abs)
+			if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+				t.Fatalf("id %q resolved to %q, which is outside the store root %q", id, abs, rootAbs)
+			}
+			// And it must be a single component: a nested path inside the root
+			// is still an id addressing something it did not create.
+			if strings.Contains(rel, string(filepath.Separator)) {
+				t.Fatalf("id %q resolved to nested path %q inside the root", id, rel)
+			}
+		})
+	}
+
+	// End to end: the write a traversing id would have performed must not
+	// appear outside the root. SetContext is the reachable writer.
+	victim := filepath.Join(outside, "context.md")
+	if err := s.SetContext("../../"+filepath.Base(outside), "planted by a traversing id"); err != nil {
+		t.Logf("SetContext returned %v (a refusal is also an acceptable outcome)", err)
+	}
+	if b, err := os.ReadFile(victim); err == nil && strings.Contains(string(b), "planted") {
+		t.Fatalf("a traversing project id wrote outside the store root: %s", victim)
+	}
+
+	// The guard must not break a real id.
+	p, err := s.Create("My Project", "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetContext(p.ID, "legitimate"); err != nil {
+		t.Fatalf("a real project id was refused: %v", err)
+	}
+	got, err := s.GetWithContext(p.ID)
+	if err != nil || !strings.Contains(got.Context, "legitimate") {
+		t.Fatalf("round trip through a real id broke: %v / %+v", err, got)
+	}
+}

--- a/server/apiroute_test.go
+++ b/server/apiroute_test.go
@@ -29,7 +29,7 @@ func TestUnroutedAPIPathsReturnJSON404(t *testing.T) {
 	} {
 		t.Run(path, func(t *testing.T) {
 			w := httptest.NewRecorder()
-			h.ServeHTTP(w, httptest.NewRequest("GET", path, nil))
+			h.ServeHTTP(w, loopbackRequest("GET", path))
 
 			if w.Code != http.StatusNotFound {
 				t.Errorf("status = %d, want 404 (got %q)", w.Code, w.Header().Get("Content-Type"))
@@ -53,7 +53,7 @@ func TestNonAPIPathsStillReachTheSPA(t *testing.T) {
 	h := newTestServer(&config.Config{}).Handler()
 	for _, path := range []string{"/", "/some/client/route"} {
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, httptest.NewRequest("GET", path, nil))
+		h.ServeHTTP(w, loopbackRequest("GET", path))
 		if w.Code != http.StatusOK {
 			t.Errorf("%s status = %d, want 200 — client routes must not 404", path, w.Code)
 		}

--- a/server/chat_handler.go
+++ b/server/chat_handler.go
@@ -353,7 +353,7 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 				}
 			}()
 			if err := s.projects.AppendRawContext(projID, fmt.Sprintf("## User\n%s\n\n## Assistant\n%s\n", q, out)); err != nil {
-				log.Printf("[server] failed to append to raw context: %v", err)
+				log.Printf("[server] failed to append to raw context: %v", core.LogSafe(err.Error()))
 			}
 			s.maybeRewriteProjectContext(projID)
 		}(req.Project, req.Query, output)

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -121,13 +121,58 @@ func isLocalhostOrigin(o string) bool {
 	return false
 }
 
+// isLoopbackHost reports whether a Host header names this machine.
+//
+// The port is not checked — the listener already decides that — but the
+// hostname must be one the browser could only have reached by resolving to
+// loopback legitimately. A bare IPv6 host arrives bracketed; SplitHostPort
+// unwraps it, and its failure means there was no port at all, so the whole
+// value is the host.
+func isLoopbackHost(host string) bool {
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		h = host
+	}
+	h = strings.Trim(h, "[]")
+	if h == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(h); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
 // csrfMiddleware blocks drive-by cross-origin requests. The server is always
 // bound to 127.0.0.1, so there is no remote attacker and no bearer token is
 // needed — but a malicious website (evil.com) open in the user's browser can
 // still issue fetch() calls to localhost. Any /api/* request (except
 // /api/health) carrying a non-loopback Origin header is rejected.
+//
+// # ORIGIN IS NOT ENOUGH, AND THIS IS WHY THE HOST CHECK IS HERE
+//
+// Origin alone leaves DNS rebinding wide open, which SECURITY.md lists as in
+// scope for this server. The attack does not send a foreign Origin — it
+// removes the need for one:
+//
+//	evil.com resolves to the attacker, serves a page, and re-resolves to
+//	127.0.0.1 on a short TTL. The page then fetches http://evil.com:12345/api/…
+//	The browser considers that SAME-ORIGIN with the page it is running, so it
+//	sends no Origin header at all, `origin != ""` is false, and the request
+//	arrives at a handler that will read and write files.
+//
+// The request still has to carry `Host: evil.com`, because that is the name
+// the browser dialled. Requiring the Host to be loopback is what closes it, and
+// it is the standard defence precisely because the attacker cannot forge it
+// without giving up the rebind.
 func (s *Server) csrfMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Every path, not just /api/: the UI itself is worth protecting, and a
+		// rebound page loading it is the first step to driving it.
+		if r.Host != "" && !isLoopbackHost(r.Host) {
+			writeError(w, http.StatusForbidden, "blocked: this server only answers to a loopback host name")
+			return
+		}
 		if strings.HasPrefix(r.URL.Path, "/api/") && r.URL.Path != "/api/health" {
 			if origin := r.Header.Get("Origin"); origin != "" && !isLocalhostOrigin(origin) {
 				writeError(w, http.StatusForbidden, "blocked: cross-origin requests are not allowed")

--- a/server/middleware_test.go
+++ b/server/middleware_test.go
@@ -87,6 +87,9 @@ func TestCSRFAllowsTheUIAndDirectClients(t *testing.T) {
 				reached = true
 			}))
 			req := httptest.NewRequest("POST", "/api/chat", nil)
+			// httptest defaults Host to example.com, which the rebinding
+			// check now refuses. A real client always dials loopback.
+			req.Host = "localhost:12345"
 			if origin != "" {
 				req.Header.Set("Origin", origin)
 			}
@@ -114,6 +117,7 @@ func TestCSRFExemptsHealthOnly(t *testing.T) {
 			reached = true
 		}))
 		req := httptest.NewRequest("GET", path, nil)
+		req.Host = "localhost:12345"
 		req.Header.Set("Origin", "https://evil.com")
 		h.ServeHTTP(httptest.NewRecorder(), req)
 
@@ -182,4 +186,82 @@ func TestRateLimiterExemptsHealthAndEvents(t *testing.T) {
 			t.Errorf("%s was rate limited", exempt)
 		}
 	}
+}
+
+// TestCSRFBlocksDNSRebinding covers the hole the Origin check could never see.
+//
+// A rebinding attacker does not send a foreign Origin — they remove the need
+// for one. evil.com serves a page, re-resolves to 127.0.0.1 on a short TTL,
+// and the page fetches http://evil.com:12345/api/…. The browser treats that as
+// SAME-ORIGIN with the page, so it sends no Origin header at all and the
+// `origin != ""` guard never fires. What the request must still carry is
+// Host: evil.com, because that is the name the browser dialled.
+//
+// Against the Origin-only middleware every case below reaches the handler.
+func TestCSRFBlocksDNSRebinding(t *testing.T) {
+	s := newTestServer(&config.Config{Model: "gpt-4o"})
+
+	blocked := map[string]string{
+		"rebound host, no Origin at all": "evil.com:12345",
+		"rebound host without a port":    "evil.com",
+		"a LAN address is not loopback":  "192.168.1.10:12345",
+		"public IP dialled directly":     "203.0.113.9:12345",
+		"loopback-looking but is not":    "127.0.0.1.evil.com:12345",
+	}
+	for name, host := range blocked {
+		t.Run(name, func(t *testing.T) {
+			reached := false
+			h := s.csrfMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				reached = true
+			}))
+			// Deliberately no Origin header: that is the whole point.
+			req := httptest.NewRequest("POST", "/api/workspace/file", nil)
+			req.Host = host
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if reached {
+				t.Errorf("a request for Host %q reached the handler", host)
+			}
+			if w.Code != http.StatusForbidden {
+				t.Errorf("status = %d, want 403", w.Code)
+			}
+		})
+	}
+
+	// The real UI must keep working, including the loopback forms a browser
+	// and a direct client actually send.
+	for name, host := range map[string]string{
+		"the UI's own host": "localhost:12345",
+		"dotted loopback":   "127.0.0.1:12345",
+		"another loopback":  "127.0.0.53:12345",
+		"IPv6 loopback":     "[::1]:12345",
+		"no port":           "localhost",
+	} {
+		t.Run(name, func(t *testing.T) {
+			reached := false
+			h := s.csrfMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				reached = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			req := httptest.NewRequest("GET", "/api/status", nil)
+			req.Host = host
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+			if !reached {
+				t.Errorf("Host %q was blocked; status %d", host, w.Code)
+			}
+		})
+	}
+}
+
+// loopbackRequest builds a request the way a real client reaches this server.
+//
+// httptest.NewRequest defaults Host to example.com, which csrfMiddleware now
+// refuses as a DNS-rebinding attempt. Every test that drives the full handler
+// stack needs a Host the server would actually be dialled on, and saying so
+// once beats a literal in each fixture.
+func loopbackRequest(method, path string) *http.Request {
+	r := httptest.NewRequest(method, path, nil)
+	r.Host = "localhost:12345"
+	return r
 }

--- a/server/planworkflow.go
+++ b/server/planworkflow.go
@@ -125,7 +125,7 @@ func (s *Server) seedProjectPlanWorkflow(projID, name, description, ctxBody stri
 			if genErr != nil {
 				reason = "Plan/workflow generation failed: " + genErr.Error() + " — click Regenerate to retry"
 			}
-			log.Printf("[server] plan/workflow generation produced nothing for %s: %v", projID, genErr)
+			log.Printf("[server] plan/workflow generation produced nothing for %s: %v", core.LogSafe(projID), core.LogSafe(genErr.Error()))
 			if s.emitter != nil {
 				s.emitter.EmitTaskUpdate("blueprint", "error", reason)
 			}

--- a/tools/observation_confinement_test.go
+++ b/tools/observation_confinement_test.go
@@ -88,3 +88,40 @@ func TestFileObservationIsConfinedToWorkspace(t *testing.T) {
 		}
 	}
 }
+
+// TestChangeSnapshotIsConfinedToWorkspace covers the same exposure on the
+// change-record path (CodeQL #51/#52/#53).
+//
+// captureFileBefore runs BEFORE the tool does, so it read whatever path the
+// model named regardless of whether the write was about to be refused.
+// write_file and patch both call confineWrite, so the write itself never lands
+// outside the workspace — but the before-snapshot of the file was captured
+// into the change record and shown in the Changes tab anyway. A refused
+// write_file to a file outside the workspace disclosed its contents.
+func TestChangeSnapshotIsConfinedToWorkspace(t *testing.T) {
+	ws := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secrets.txt")
+	if err := os.WriteFile(outside, []byte("token=hunter2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, content, existed := captureFileBefore(withWorkspace(ws),
+		"write_file", map[string]interface{}{"path": outside})
+	if strings.Contains(content, "hunter2") {
+		t.Fatalf("a file outside the workspace was snapshotted into a change record: %q", content)
+	}
+	if existed {
+		t.Fatal("an out-of-workspace file was reported as captured")
+	}
+
+	// An in-workspace file must still be snapshotted, or rollback breaks.
+	inWS := filepath.Join(ws, "real.txt")
+	if err := os.WriteFile(inWS, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, content, existed = captureFileBefore(withWorkspace(ws),
+		"write_file", map[string]interface{}{"path": inWS})
+	if !existed || content != "original" {
+		t.Fatalf("an in-workspace snapshot broke: existed=%v content=%q", existed, content)
+	}
+}

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -517,6 +517,19 @@ func denySuffix(req permission.ApprovalRequest) string {
 
 // captureFileBefore reads the current content of the file that a file-mutating
 // tool is about to touch. Returns (path, content, existed).
+// readIfWithinWorkspace reads a file only when it is inside the active
+// workspace, returning empty otherwise. The after-snapshot has the same
+// exposure as the before-snapshot in captureFileBefore: it runs on a
+// model-supplied path and its result is displayed and stored.
+func readIfWithinWorkspace(ctx context.Context, path string) string {
+	safe, err := withinWorkspace(ctx, path)
+	if err != nil {
+		return ""
+	}
+	b, _ := os.ReadFile(safe)
+	return string(b)
+}
+
 func captureFileBefore(ctx context.Context, tool string, args map[string]interface{}) (string, string, bool) {
 	if tool != "write_file" && tool != "patch" {
 		return "", "", false
@@ -526,6 +539,18 @@ func captureFileBefore(ctx context.Context, tool string, args map[string]interfa
 		return "", "", false
 	}
 	path = expandPath(ctx, path)
+	// This runs BEFORE the tool does, so it reads whatever path the model
+	// named whether or not the write is about to be refused. write_file and
+	// patch both call confineWrite, so a target outside the workspace never
+	// gets written — but without this the before-snapshot of that file was
+	// still captured into the change record and shown in the Changes tab.
+	// Confining the snapshot to the same subtree the write is confined to
+	// keeps the two policies identical.
+	safe, cerr := withinWorkspace(ctx, path)
+	if cerr != nil {
+		return path, "", false
+	}
+	path = safe
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return path, "", false
@@ -556,24 +581,24 @@ func (r *Registry) recordChange(ctx context.Context, tool string, args map[strin
 		if path == "" {
 			path = expandPath(ctx, str(args["path"]))
 		}
-		after, _ := os.ReadFile(path)
+		after := readIfWithinWorkspace(ctx, path)
 		c.Kind = core.ChangeFileModify
 		if !beforeExists {
 			c.Kind = core.ChangeFileCreate
 		}
 		c.Path = path
 		c.Before = beforeContent
-		c.After = string(after)
+		c.After = after
 	case "patch":
 		path := beforePath
 		if path == "" {
 			path = expandPath(ctx, str(args["path"]))
 		}
-		after, _ := os.ReadFile(path)
+		after := readIfWithinWorkspace(ctx, path)
 		c.Kind = core.ChangeFileModify
 		c.Path = path
 		c.Before = beforeContent
-		c.After = string(after)
+		c.After = after
 	case "terminal":
 		c.Kind = core.ChangeCommand
 		c.Command = str(args["command"])

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -353,7 +353,7 @@ func (r *Registry) snapshot(tool string) {
 		return
 	}
 	if _, err := ckpt.Snapshot(tool, "before "+tool); err != nil {
-		log.Printf("checkpoint: snapshot before %s failed: %v", tool, err)
+		log.Printf("checkpoint: snapshot before %s failed: %v", core.LogSafe(tool), core.LogSafe(err.Error()))
 	}
 }
 


### PR DESCRIPTION
The first full CodeQL scan of `main` returned 55 alerts. PR checks only report alerts in *changed* code, so none of it was visible until the scan ran against the whole tree.

All 55 are dispositioned. `docs/CODEQL_TRIAGE.md` holds the reasoning; the dismissals in the UI carry a 280-char pointer to it.

## Fixed — four real bugs

**Path traversal in `project/store.go` (15 alerts).** Every path helper funnels through `dir(id)` = `filepath.Join(s.root, id)` with no check. `chat_handler.go:190` passes `req.Project` straight off the request body into `Get`/`GetPlan`/`GetWorkflow`. An id of `../../../../etc` resolved to `/etc`, and `SetContext` would have written its `context.md` there.

**Reads on model-supplied paths in `tools/registry.go` (4 alerts).** The tool call was never the problem — the permission gate decides what the agent may look at. Where the bytes went was. `noteFileObservation` fed them to the knowledge graph, so an approved one-off read of `~/.ssh/config` became a durable belief. `captureFileBefore` runs *before* the tool, so a `write_file` to `/etc/shadow` that `confineWrite` refused had already snapshotted the file into the change record and rendered it in the Changes tab.

**Log injection (3 alerts).** Three `log.Printf` sites interpolate model-controlled values. This log is the record of what the agent did to your machine, so a forged line is worth more here than usual.

**DNS rebinding — not a CodeQL alert.** It surfaced from asking what the eight `workspace_handlers.go` alerts were reachable by. `csrfMiddleware` checked `Origin` only, and rebinding removes the need for one: `evil.com` re-resolves to `127.0.0.1`, the page fetches same-origin, no `Origin` header is sent, and the request lands on handlers that read files, write files and run tools. It must still carry `Host: evil.com`. Now required to be loopback on every path.

Every fix has a regression test that fails against the old code, with the failure quoted in its commit message.

## Dismissed — 33

9 where a sanitiser is present that CodeQL cannot model (`safeurl` for SSRF, `filepath.Base` for zipslip and symlink entries, `config.Values()` masking for the settings print, the existing `HasPrefix` containment in `handleFilesRead`) — each names its test.

24 across the trust boundary `SECURITY.md` already states: a local program, running as the user, opening a path the user or their agent named. The file picker cannot attach from `~/Documents` if it cannot browse there. That dismissal is only defensible because the boundary is now enforced — loopback bind, CSRF, and the Host check above. Without the last one it would not have been.

Nothing is dismissed as a class.

## After this merges

The 22 alerts still open are exactly the ones fixed here; they close on the next scan. Once `main` is clean, CodeQL is worth adding to the required status checks — that was deferred precisely because it was red.