### PR TITLE
ignore the roadmap draft alongside the other comparison material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ coverage.out
 # project deliberately keeps out of its history.
 DARKCODE_VS_HERMES_AGENT.md
 AGENT_LANDSCAPE_*.md
+/text.txt
 THESIS.md
 HANDOFF_PROMPT.md
 NEXT_SESSION_PROMPT.md


### PR DESCRIPTION
`text.txt` — a market and competitive analysis of coding agents — was sitting untracked and unignored at the repo root. The working rules keep comparison material out of the repository entirely, and one `git add -A` would have published it to a public repo. Same hazard class as `extra/.config` and the vs-hermes draft already in this list.

No secrets in the file; the objection is that it is comparison material at all.