### PR TITLE
Close two text.txt gaps: test/CI write-lock + repo-rules ingestion

### DIFF
--- a/app_wireup.go
+++ b/app_wireup.go
@@ -653,6 +653,7 @@ func (a *AppRunner) initKernelAndServer(memDir string) {
 	// Hand the kernel the client factory so ReloadModels can rebuild clients on
 	// a live config change without the orchestrator importing llm.
 	a.Kernel.SetClientFactory(a.createClient)
+	a.Kernel.SetRepoRules(a.Cfg.RepoRules)
 	a.Recorder = tools.NewChangeRecorder()
 	a.Kernel.SetChangeRecorder(a.Recorder)
 

--- a/cli/commands.go
+++ b/cli/commands.go
@@ -72,6 +72,7 @@ var commandRegistry = []cmdInfo{
 	{"/plugins", "Tools & System", "List loaded plugins"},
 	{"/pipeline", "Tools & System", "Show the verification pipeline"},
 	{"/permissions", "Tools & System", "Show permission-gate settings"},
+	{"/lock-tests", "Tools & System", "/lock-tests on|off — deny writes to test files and CI config"},
 
 	// Observability
 	{"/monitor", "Observability", "Open the live monitoring dashboard"},

--- a/cli/console.go
+++ b/cli/console.go
@@ -65,6 +65,9 @@ type Console struct {
 	projects      *project.Store
 	ckpt          *checkpoint.Manager
 	activeProject string
+	// testLock mirrors the gate's test/CI write-lock state for /lock-tests'
+	// no-argument status report — the gate itself doesn't expose a getter.
+	testLock bool
 
 	// extCommands are the slash commands loaded extension bundles offer,
 	// consulted just before the console reports an unknown command.
@@ -841,6 +844,37 @@ func (c *Console) printPermissions(args []string) {
 	fmt.Printf("  %-18s %s\n", paint(cGray, "session allows"), paint(cBlue, fmtNum(stats.SessionAll)))
 	fmt.Printf("  %-18s %s\n", paint(cGray, "session denies"), paint(cRed, fmtNum(stats.SessionDeny)))
 	fmt.Printf("\n  %s /permissions reset to clear session decisions\n", paint(cGray, ""))
+}
+
+// handleLockTests toggles the test/CI write lock: `/lock-tests on` denies
+// writes to test files and CI config for the rest of the session (without
+// disturbing any deny rules the user configured separately); `/lock-tests
+// off` restores them. Bare `/lock-tests` reports the current state.
+func (c *Console) handleLockTests(args []string) {
+	if c.gate == nil {
+		fmt.Println(paint(cGray, "  permission gate not installed."))
+		return
+	}
+	if len(args) == 0 {
+		state := paint(cGray, "off")
+		if c.testLock {
+			state = paint(cGreen, "on")
+		}
+		fmt.Printf("  test/CI write lock: %s %s\n", state, paint(cGray, "(/lock-tests on|off)"))
+		return
+	}
+	switch args[0] {
+	case "on":
+		c.gate.SetTestLock(true)
+		c.testLock = true
+		fmt.Println(paint(cGreen, "✓") + paint(cGray, " test files and CI config are now read-only for tool writes."))
+	case "off":
+		c.gate.SetTestLock(false)
+		c.testLock = false
+		fmt.Println(paint(cGreen, "✓") + paint(cGray, " test/CI write lock disabled."))
+	default:
+		fmt.Println(paint(cRed, "✗") + paint(cGray, " usage: /lock-tests on|off"))
+	}
 }
 
 // printUsageDelta prints a compact usage summary for the requests made since

--- a/cli/console_commands.go
+++ b/cli/console_commands.go
@@ -400,6 +400,9 @@ func (c *Console) handleSlash(input string) bool {
 	case "/permissions", "/perms":
 		c.printPermissions(parts[1:])
 
+	case "/lock-tests":
+		c.handleLockTests(parts[1:])
+
 	default:
 		// An extension bundle may own this name. Checked here rather than in the
 		// switch above because built-ins win: a bundle must not be able to

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,12 @@ import (
 
 // Config holds all agent configuration.
 type Config struct {
+	// RepoRules is the content of the repo's rules file (AGENTS.md,
+	// .darkcode/RULES.md, or CLAUDE.md — first found), loaded fresh from the
+	// working directory at every Load. Not persisted: it always reflects the
+	// file on disk, never a stale copy from a saved config.
+	RepoRules string `json:"-"`
+
 	// --- Single model (backward compatible) ---
 	Model         string  `json:"model"`
 	Provider      string  `json:"provider"`
@@ -548,6 +554,9 @@ func Load() (*Config, error) {
 		if os.IsNotExist(err) {
 			// Try environment variables as fallback
 			applyEnv(cfg)
+			if wd, wderr := os.Getwd(); wderr == nil {
+				cfg.RepoRules = loadRepoRules(wd)
+			}
 			return cfg, nil
 		}
 		return nil, fmt.Errorf("read config: %w", err)
@@ -610,6 +619,10 @@ func Load() (*Config, error) {
 	// but surface portability/logic problems to stderr so they aren't silent.
 	if verr := cfg.Validate(); verr != nil {
 		fmt.Fprintf(os.Stderr, "Warning: config validation: %v\n", verr)
+	}
+
+	if wd, err := os.Getwd(); err == nil {
+		cfg.RepoRules = loadRepoRules(wd)
 	}
 
 	return cfg, nil

--- a/config/load_repo_rules_test.go
+++ b/config/load_repo_rules_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLoadPopulatesRepoRulesFromCWD covers the wiring, not just the loader:
+// Load() must call loadRepoRules against the working directory on every
+// call, including the common case where no config.json exists yet.
+func TestLoadPopulatesRepoRulesFromCWD(t *testing.T) {
+	t.Setenv("DARKCODE_CONFIG", "")
+	t.Setenv("HOME", t.TempDir())
+	tmpCwd := t.TempDir()
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(tmpCwd); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+
+	writeRulesFile(t, tmpCwd, "AGENTS.md", "always run tests before committing")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.RepoRules != "always run tests before committing" {
+		t.Errorf("Load().RepoRules = %q, want the AGENTS.md content", cfg.RepoRules)
+	}
+}

--- a/config/repo_rules.go
+++ b/config/repo_rules.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// repoRulesMaxBytes bounds how much of a rules file gets injected into the
+// system prompt every turn, so a large file can't eat the context budget.
+const repoRulesMaxBytes = 32 * 1024
+
+// repoRulesCandidates are checked in order at the repo root; the first one
+// found wins. AGENTS.md is the cross-tool convention several other agents
+// already read; .darkcode/RULES.md and CLAUDE.md are checked after so an
+// existing file from either convention still gets picked up.
+var repoRulesCandidates = []string{
+	"AGENTS.md",
+	filepath.Join(".darkcode", "RULES.md"),
+	"CLAUDE.md",
+}
+
+// loadRepoRules reads the first repo-rules file found under dir, capped at
+// repoRulesMaxBytes. Returns "" if none exist or dir can't be read.
+func loadRepoRules(dir string) string {
+	for _, name := range repoRulesCandidates {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		if len(data) > repoRulesMaxBytes {
+			data = data[:repoRulesMaxBytes]
+		}
+		return string(data)
+	}
+	return ""
+}

--- a/config/repo_rules_test.go
+++ b/config/repo_rules_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeRulesFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	full := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadRepoRulesPrefersAgentsMD(t *testing.T) {
+	dir := t.TempDir()
+	writeRulesFile(t, dir, "AGENTS.md", "agents rules")
+	writeRulesFile(t, dir, "CLAUDE.md", "claude rules")
+	writeRulesFile(t, dir, ".darkcode/RULES.md", "darkcode rules")
+
+	if got := loadRepoRules(dir); got != "agents rules" {
+		t.Errorf("got %q, want AGENTS.md content", got)
+	}
+}
+
+func TestLoadRepoRulesFallsBackToDarkcodeRules(t *testing.T) {
+	dir := t.TempDir()
+	writeRulesFile(t, dir, ".darkcode/RULES.md", "darkcode rules")
+	writeRulesFile(t, dir, "CLAUDE.md", "claude rules")
+
+	if got := loadRepoRules(dir); got != "darkcode rules" {
+		t.Errorf("got %q, want .darkcode/RULES.md content (AGENTS.md absent)", got)
+	}
+}
+
+func TestLoadRepoRulesFallsBackToClaudeMD(t *testing.T) {
+	dir := t.TempDir()
+	writeRulesFile(t, dir, "CLAUDE.md", "claude rules")
+
+	if got := loadRepoRules(dir); got != "claude rules" {
+		t.Errorf("got %q, want CLAUDE.md content", got)
+	}
+}
+
+func TestLoadRepoRulesEmptyWhenNoneExist(t *testing.T) {
+	dir := t.TempDir()
+	if got := loadRepoRules(dir); got != "" {
+		t.Errorf("got %q, want empty string when no rules file exists", got)
+	}
+}
+
+func TestLoadRepoRulesCapsAt32KiB(t *testing.T) {
+	dir := t.TempDir()
+	writeRulesFile(t, dir, "AGENTS.md", strings.Repeat("x", 40000))
+
+	got := loadRepoRules(dir)
+	if len(got) != 32*1024 {
+		t.Errorf("got %d bytes, want capped to 32KiB", len(got))
+	}
+}

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -106,6 +106,9 @@ type ReActLoop struct {
 	// fan-out and sub-agent calls, so a limit was checked once and then
 	// exceeded several times over inside the run it was meant to bound.
 	budget func() error
+	// repoRules is the repo's rules file content (config.Config.RepoRules),
+	// appended to the system prompt when non-empty.
+	repoRules string
 }
 
 // New creates a ReAct loop wired to the model router, tool registry, and event
@@ -138,6 +141,10 @@ func (l *ReActLoop) SetModels(m *modelport.Manager) {
 // It returns an error rather than a bool so the reason reaches the user: "the
 // run stopped" without saying why reads as the agent giving up.
 func (l *ReActLoop) SetBudgetCheck(fn func() error) { l.budget = fn }
+
+// SetRepoRules installs the repo's rules file content, appended to the
+// system prompt on every turn while it's set.
+func (l *ReActLoop) SetRepoRules(rules string) { l.repoRules = rules }
 
 // BudgetCheckInstalled reports whether a spend check is wired. It exists so a
 // caller can prove the wiring rather than assume it: the check is installed on
@@ -748,6 +755,11 @@ func (l *ReActLoop) systemPrompt() string {
 	b.WriteString("- Prefer parallel tool calls when actions are independent (they execute concurrently).\n")
 	b.WriteString("- Be concise in intermediate thoughts; reserve detail for the final answer.\n")
 	b.WriteString("- If a tool result says \"permission denied by user\" with feedback, honour that steer and change your approach accordingly.\n")
+	if l.repoRules != "" {
+		b.WriteString("\n## Project Rules\n")
+		b.WriteString(l.repoRules)
+		b.WriteString("\n")
+	}
 	return b.String()
 }
 

--- a/loop/system_prompt_test.go
+++ b/loop/system_prompt_test.go
@@ -1,0 +1,27 @@
+package loop
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/darkcode/tools"
+)
+
+func TestSystemPromptIncludesRepoRulesWhenSet(t *testing.T) {
+	l := New(newTestRouter(&fakeLLMClient{}), tools.NewRegistry(), nil, 1)
+	l.SetRepoRules("never commit directly to main")
+
+	got := l.systemPrompt()
+	if !strings.Contains(got, "never commit directly to main") {
+		t.Error("system prompt is missing the repo rules content")
+	}
+}
+
+func TestSystemPromptOmitsRepoRulesSectionWhenEmpty(t *testing.T) {
+	l := New(newTestRouter(&fakeLLMClient{}), tools.NewRegistry(), nil, 1)
+
+	got := l.systemPrompt()
+	if strings.Contains(got, "Project Rules") {
+		t.Error("system prompt should omit the Project Rules section when no rules are configured")
+	}
+}

--- a/orchestrator/kernel.go
+++ b/orchestrator/kernel.go
@@ -384,6 +384,14 @@ func (k *Kernel) SetClientFactory(fn func(config.ModelConfig) core.LLMClient) {
 	k.newClient = fn
 }
 
+// SetRepoRules forwards the repo's rules file content (config.Config.RepoRules)
+// to the agentic loop, which appends it to the system prompt.
+func (k *Kernel) SetRepoRules(rules string) {
+	if k.agenticLoop != nil {
+		k.agenticLoop.SetRepoRules(rules)
+	}
+}
+
 // SetCheckpoints installs the workspace snapshotter, both on the tool registry
 // (which takes the pre-mutation snapshot) and on the kernel, so every surface
 // can offer rollback from one owner.

--- a/permission/gate.go
+++ b/permission/gate.go
@@ -160,6 +160,9 @@ type Gate struct {
 
 	// denyRules refuse matching calls ahead of every permissive path.
 	denyRules []DenyRule
+	// testLockRules is the optional test/CI write-lock preset, kept separate
+	// from denyRules so toggling it never clobbers the user's own rules.
+	testLockRules []DenyRule
 	// allowedTools, when non-empty, is a whitelist; anything unlisted is
 	// refused regardless of level or prior session approval.
 	allowedTools []string
@@ -279,6 +282,11 @@ func (g *Gate) deniedByRule(tool string, args map[string]interface{}) (DenyRule,
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	for _, r := range g.denyRules {
+		if r.matches(tool, args) {
+			return r, true
+		}
+	}
+	for _, r := range g.testLockRules {
 		if r.matches(tool, args) {
 			return r, true
 		}

--- a/permission/lock_tests.go
+++ b/permission/lock_tests.go
@@ -1,0 +1,29 @@
+package permission
+
+// LockTestsDenyRules is the preset that keeps test suites and CI config
+// read-only. It exists so an automated fix loop cannot satisfy its own
+// verifier by weakening the assertions it is being checked against.
+func LockTestsDenyRules() []string {
+	tools := []string{"write_file", "patch", "replace_file_content"}
+	patterns := []string{"*_test.go", ".github/workflows/*", ".gitlab-ci.yml"}
+	var rules []string
+	for _, tool := range tools {
+		for _, pattern := range patterns {
+			rules = append(rules, tool+":"+pattern)
+		}
+	}
+	return rules
+}
+
+// SetTestLock enables or disables the test/CI write lock, independent of the
+// user's own deny rules — toggling it off must never clear rules the user set
+// separately via SetDenyRules.
+func (g *Gate) SetTestLock(on bool) {
+	g.mu.Lock()
+	if on {
+		g.testLockRules = ParseDenyRules(LockTestsDenyRules())
+	} else {
+		g.testLockRules = nil
+	}
+	g.mu.Unlock()
+}

--- a/permission/lock_tests_test.go
+++ b/permission/lock_tests_test.go
@@ -1,0 +1,70 @@
+package permission
+
+import "testing"
+
+// Test-lock denies writes to test files and CI config while leaving
+// everything else — including the user's own deny rules — untouched.
+func TestLockTestsDeniesTestFileWrites(t *testing.T) {
+	g := NewGate(LevelRelaxed)
+	g.SetApprover(AutoApprover())
+	g.SetTestLock(true)
+
+	blocked := []struct {
+		tool string
+		path string
+	}{
+		{"write_file", "foo_test.go"},
+		{"write_file", "pkg/bar_test.go"},
+		{"patch", "pkg/bar_test.go"},
+		{"replace_file_content", "pkg/bar_test.go"},
+		{"write_file", ".github/workflows/ci.yml"},
+		{"patch", ".gitlab-ci.yml"},
+	}
+	for _, tc := range blocked {
+		args := map[string]interface{}{"path": tc.path}
+		if allowed, _, feedback := g.Check(tc.tool, args); allowed {
+			t.Errorf("%s %s: test lock did not block", tc.tool, tc.path)
+		} else if feedback == "" {
+			t.Errorf("%s %s: denial should explain which rule fired", tc.tool, tc.path)
+		}
+	}
+
+	// Non-test, non-CI files still go through.
+	if allowed, _, _ := g.Check("write_file", map[string]interface{}{"path": "main.go"}); !allowed {
+		t.Error("test lock blocked a non-test file")
+	}
+	// Reading a test file is unaffected — only writes are locked.
+	if allowed, _, _ := g.Check("read_file", map[string]interface{}{"path": "foo_test.go"}); !allowed {
+		t.Error("test lock blocked reading a test file")
+	}
+}
+
+func TestLockTestsOffRestoresWrites(t *testing.T) {
+	g := NewGate(LevelRelaxed)
+	g.SetApprover(AutoApprover())
+	g.SetTestLock(true)
+	g.SetTestLock(false)
+
+	if allowed, _, _ := g.Check("write_file", map[string]interface{}{"path": "foo_test.go"}); !allowed {
+		t.Error("toggling test lock off did not restore test-file writes")
+	}
+}
+
+func TestLockTestsCoexistsWithUserDenyRules(t *testing.T) {
+	g := NewGate(LevelRelaxed)
+	g.SetApprover(AutoApprover())
+	g.SetDenyRules([]string{"git:push"})
+	g.SetTestLock(true)
+
+	if allowed, _, _ := g.Check("git", map[string]interface{}{"args": "push"}); allowed {
+		t.Error("user deny rule lost when test lock was enabled")
+	}
+	if allowed, _, _ := g.Check("write_file", map[string]interface{}{"path": "foo_test.go"}); allowed {
+		t.Error("test lock did not apply alongside a pre-existing user deny rule")
+	}
+
+	g.SetTestLock(false)
+	if allowed, _, _ := g.Check("git", map[string]interface{}{"args": "push"}); allowed {
+		t.Error("turning test lock off should not clear the user's own deny rules")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the two real gaps found when comparing darkcode against the text.txt
competitive-landscape doc (everything else it lists — cloud microVM sandboxes,
a production deployment layer, multi-provider BYOK breadth — is a deliberate
local-first exclusion, not addressed here).

- **`/lock-tests on|off`** — denies `write_file`/`patch`/`replace_file_content`
  against `*_test.go` and CI config globs, so an automated fix loop can't
  satisfy its own verifier by weakening the assertions it's being checked
  against. Built on the existing deny-rule engine (already proven to beat
  every permissive path); kept as a separate rule set from the user's own
  `SetDenyRules` so toggling it never clobbers rules they configured
  themselves. Default off — selfheal's own `untested-hotspot`/`missing-test`
  fixes legitimately *write* new test files.
- **Repo-rules ingestion** — `config.Load()` now reads the first of
  `AGENTS.md` / `.darkcode/RULES.md` / `CLAUDE.md` found at the repo root
  (capped 32KiB) and threads it into the primary ReAct loop's system prompt
  as a `## Project Rules` section. Scoped to that one execution path;
  wiring the other prompt-assembly sites is a separate follow-up.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — 49/49 packages pass, 0 FAIL
- [x] Every new behavior is TDD'd: written failing first, watched fail for
      the right reason, then made to pass (`permission`, `config`, `loop`
      packages)
- [x] `config.Load()`'s repo-rules wiring specifically verified as a real
      regression test: reverted, watched it fail, restored byte-identically
      (sha256 match)